### PR TITLE
Adds Sentry Exception monitoring

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -15,6 +15,7 @@ requests-mock = "*"
 flask = "*"
 gunicorn = "*"
 requests = "*"
+sentry-sdk = {extras = ["flask"],version = "*"}
 
 [requires]
 python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "02eb052a699e050612f6c0c13c31b5ff780530ce6bf2df1cd5127fbbc14bd374"
+            "sha256": "cf25cc6e64d8b1065bf4cc7aaf68831a126b2cb0d7fae3bf09ee9c01a794761d"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,6 +16,12 @@
         ]
     },
     "default": {
+        "blinker": {
+            "hashes": [
+                "sha256:471aee25f3992bd325afa3772f1063dbdbbca947a041b8b89466dc00d606f8b6"
+            ],
+            "version": "==1.4"
+        },
         "certifi": {
             "hashes": [
                 "sha256:017c25db2a153ce562900032d5bc68e9f191e44e9a0f762f373977de9df1fbb3",
@@ -114,6 +120,17 @@
             ],
             "index": "pypi",
             "version": "==2.22.0"
+        },
+        "sentry-sdk": {
+            "extras": [
+                "flask"
+            ],
+            "hashes": [
+                "sha256:05285942901d38c7ce2498aba50d8e87b361fc603281a5902dda98f3f8c5e145",
+                "sha256:c6b919623e488134a728f16326c6f0bcdab7e3f59e7f4c472a90eea4d6d8fe82"
+            ],
+            "index": "pypi",
+            "version": "==0.13.5"
         },
         "urllib3": {
             "hashes": [
@@ -227,11 +244,11 @@
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:b044f07694ef14a6683b097ba56bd081dbc7cdc7c7fe46011e499dfecc082f21",
-                "sha256:e6ac600a142cf2db707b1998382cc7fc3b02befb7273876e01b8ad10b9652742"
+                "sha256:073a852570f92da5f744a3472af1b61e28e9f78ccf0c9117658dc32b15de7b45",
+                "sha256:d95141fbfa7ef2ec65cfd945e2af7e5a6ddbd7c8d9a25e66ff3be8e3daf9f60f"
             ],
             "markers": "python_version < '3.8'",
-            "version": "==1.1.0"
+            "version": "==1.3.0"
         },
         "mccabe": {
             "hashes": [
@@ -242,10 +259,10 @@
         },
         "more-itertools": {
             "hashes": [
-                "sha256:53ff73f186307d9c8ef17a9600309154a6ae27f25579e80af4db8f047ba14bc2",
-                "sha256:a0ea684c39bc4315ba7aae406596ef191fd84f873d2d2751f84d64e81a7a2d45"
+                "sha256:b84b238cce0d9adad5ed87e745778d20a3f8487d0f0cb8b8a586816c7496458d",
+                "sha256:c833ef592a0324bcc6a60e48440da07645063c453880c9477ceb22490aec1564"
             ],
-            "version": "==8.0.0"
+            "version": "==8.0.2"
         },
         "packaging": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -38,3 +38,10 @@ docker build -t worldcatinator .
 
 docker run -it -p 5000:5000 worldcatinator
 ```
+
+## Environment Variables
+
+- `SENTRY_DSN` (optional). If set to a valid value (obtain from Sentry),
+  exceptions will be sent to Sentry
+- `TIMDEX_URL` (default is to production TIMDEX). Set to stage, PR or local
+  TIMDEX endpoint if you have reason to do so

--- a/worldcatinator/__init__.py
+++ b/worldcatinator/__init__.py
@@ -2,8 +2,18 @@ import logging
 import os
 
 import requests
+import sentry_sdk
+from sentry_sdk.integrations.flask import FlaskIntegration
 
 from flask import Flask, redirect, request
+
+sentry_dsn = os.getenv('SENTRY_DSN') or None
+
+if sentry_dsn:
+    sentry_sdk.init(
+        sentry_dsn,
+        integrations=[FlaskIntegration()]
+    )
 
 app = Flask(__name__)
 app.config['TIMDEX_URL'] = os.getenv('TIMDEX_URL',
@@ -47,3 +57,8 @@ def worldcatinator():
 @app.route('/ping')
 def ping():
     return "pong"
+
+
+@app.route('/debug-sentry')
+def trigger_error():
+    1 / 0


### PR DESCRIPTION
- `SENTRY_DSN` can be set to a valid configuration to enable Sentry
- If `SENTRY_DSN` is not set, we do not send them to Sentry
- an intentionally broken route is provided for convenience to easily
  validate this is working as expected

## How can a reviewer see these changes?

On the PR build, hit the debug sentry route. Check in sentry for said exception.

## Reviewer Checklist

- [x] The commit message (not just PR comment) is clear and follows our
  guidelines
- [ ] There are tests covering any new functionality
- [x] The documentation has been updated if necessary
- [ ] The changes, if applicable, have been verified
- [ ] Any questions or concerns have been noted in the PR or on Slack,
  discussed if appropriate, and addressed to my satisfaction
